### PR TITLE
New CI

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,0 +1,30 @@
+---
+name: Merges
+
+# yamllint disable-line rule:truthy
+on:
+  push:
+    branches:
+      - main
+env:
+  DOCKER_BUILDCONTEXT: '.'
+  DOCKER_FILEPATH: 'Dockerfile'
+  DOCKER_REPOSITORY: ${{ github.repository }}
+  DOCKER_IMAGE: ${{ github.event.repository.name }}
+
+
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker/build-push-action@v1
+        with:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: docker.pkg.github.com
+          repository: ${{ env.DOCKER_REPOSITORY }}/${{ env.DOCKER_IMAGE }}
+          path: ${{ env.DOCKER_BUILDCONTEXT }}
+          dockerfile: ${{ env.DOCKER_FILEPATH }}
+          tag_with_ref: true
+

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,26 @@
+---
+name: Pull Requests
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request:
+    branches:
+      - main
+env:
+  DOCKER_BUILDCONTEXT: '.'
+  DOCKER_FILEPATH: 'Dockerfile'
+  DOCKER_IMAGE: ${{ github.event.repository.name }}
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker/build-push-action@v1
+        with:
+          repository: ${{ github.repository }}/${{ env.DOCKER_IMAGE }}
+          path: ${{ env.DOCKER_BUILDCONTEXT }}
+          dockerfile: ${{ env.DOCKER_FILEPATH }}
+          push: false
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+---
+name: Releases
+
+# yamllint disable-line rule:truthy
+on:
+  push:
+    tags:
+      - '**'
+
+env:
+  DOCKER_BUILDCONTEXT: '.'
+  DOCKER_FILEPATH: 'Dockerfile'
+  DOCKER_REPOSITORY: ${{ github.repository }}
+  DOCKER_IMAGE: ${{ github.event.repository.name }}
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker/build-push-action@v1
+        with:
+          repository: ${{ env.DOCKER_REPOSITORY }}/${{ env.DOCKER_IMAGE }}
+          path: ${{ env.DOCKER_BUILDCONTEXT }}
+          dockerfile: ${{ env.DOCKER_FILEPATH }}
+          tag_with_ref: true
+


### PR DESCRIPTION
Add new CI please!
# CI/CD on github-actions

This pull request adds The Linux Foundation docker
toolchain for CI/CD workflows on github-actions.

## Toolchain

The CI/CD workflows for this repository are triggered by the following:

* Pull Requests: pull requests against main will verify the project
  container can be built. The container won't be pushed anywhere.
* Merge: Merges to the repository build the docker container and tag it
  with ':latest', and 
  push it to github-packages. 
* Release: On tags, the container is built, tagged with both the
  specified tag and ':latest' and pushed to github-packages.


## Docker Environment Variables

The following variables are available to workflows:
- `$DOCKER_IMAGE`
  Name of the docker image to create
- `$DOCKER_BUILDCONTEXT`
  Path to the build context for the docker image
- `$DOCKER_FILEPATH`
  Path to the Dockerfile being built
- `$DOCKER_REPOSITORY`
  Name of the docker registry repository where the image will be
  distributed


## Updating this Pull Request

If these workflows don't match the needs for your project feel free to
[modify](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/checking-out-pull-requests-locally) them to meet your needs.

Signed-off-by: ITX CI \<itx@linuxfoundation.org\>
on-behalf-of: @linuxfoundation-it \<itx@linuxfoundation.org\>